### PR TITLE
Fix issue #46, no longer create config on server side

### DIFF
--- a/common/src/main/java/de/keksuccino/justzoom/JustZoom.java
+++ b/common/src/main/java/de/keksuccino/justzoom/JustZoom.java
@@ -14,7 +14,7 @@ public class JustZoom {
     public static final String VERSION = "2.1.1";
     public static final String LOADER = Services.PLATFORM.getPlatformName().toUpperCase();
     public static final String MOD_ID = "justzoom";
-    public static final File MOD_DIR = createDirectory(new File(GameDirectoryUtils.getGameDirectory(), "/config/justzoom"));
+    public static final File MOD_DIR = new File(GameDirectoryUtils.getGameDirectory(), "/config/justzoom");
 
     private static Options options;
 
@@ -23,6 +23,7 @@ public class JustZoom {
         if (Services.PLATFORM.isOnClient()) {
 
             LOGGER.info("[JUST ZOOM] Starting version " + VERSION + " on " + Services.PLATFORM.getPlatformDisplayName() + "..");
+            createDirectory(MOD_DIR);
 
         } else {
 


### PR DESCRIPTION
Fixes #46 
The fix should be identical across all branches(:

While looking at this I also noticed a tiny fault in Konkrete [here](https://github.com/Keksuccino/Konkrete/blob/6ab64584c96589196b35437d1df11aad035cfc71/common/src/main/java/de/keksuccino/konkrete/config/Config.java#L44), `mkdirs` isn't called if the file doesn't exist, you could probably just remove L42.